### PR TITLE
Removes caret from regex

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -356,7 +356,7 @@ class Updraft_Manager_Updater_1_5 {
 			// Prevent false-positives
 			if (file_exists(dirname($this->plugin_file).'/readme.txt') && $fp = fopen(dirname($this->plugin_file).'/readme.txt', 'r')) {
 				$file_data = fread($fp, 1024);
-				if (preg_match("/^Tested up to: (\d+\.\d+).*(\r|\n)/", $file_data, $matches)) {
+				if (preg_match("/Tested up to: (\d+\.\d+).*(\r|\n)/", $file_data, $matches)) {
 					$readme_says = $matches[1];
 				}
 				fclose($fp);


### PR DESCRIPTION
@DavidAnderson684 The `^` requires the text to be at the start of the string, which isn't needed. 

What ends up happening is the readme is ignored.
<img width="1265" alt="screen shot 2018-12-06 at 4 45 44 pm" src="https://user-images.githubusercontent.com/1478421/49579562-2b743900-f97f-11e8-9aa0-39ff9cae71ab.png">

When the readme looks like:
```
=== MetaSlider Pro ===

Requires at least: 3.5
Tested up to: 5.1
Stable tag: 2.11.0
```
