### PR TITLE
WordPress 5.5.x auto-updates UI integration

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -164,7 +164,9 @@ class Updraft_Manager_Updater_1_8 {
 
 		if (!isset($item->slug) || $item->slug != $this->slug || !$this->allow_auto_updates) return $update;
 
-		$option_auto_update_settings = (array) get_site_option('auto_update_plugins', array());
+		$option_auto_update_settings = $this->get_option('auto_update_plugins');
+
+		if (!is_array($option_auto_update_settings)) $option_auto_update_settings = array();
 		
 		$update = in_array($item->plugin, $option_auto_update_settings, true);
 		
@@ -947,32 +949,37 @@ class Updraft_Manager_Updater_1_8 {
 	 * This needs to be done in order to maintain auto-updates compatibility between WordPress and UDM and to synchronise the auto-updates setting for both
 	 */
 	public function remove_auto_update_option() {
-		$options = get_site_option($this->option_name);
+		$options = $this->get_option($this->option_name);
+		if (!is_array($options)) $options = array();
 		$old_setting_value = isset($options['auto_update']) ? $options['auto_update'] : '';
 		unset($options['auto_update']);
-		$new_setting_value = (array) get_site_option('auto_update_plugins', array());
+		$this->update_option($this->option_name, $options);
+		$new_setting_value = $this->get_option('auto_update_plugins');
+		if (!is_array($new_setting_value)) $new_setting_value = array();
 		if (!empty($old_setting_value)) $new_setting_value[] = $this->relative_plugin_file;
 		$new_setting_value = array_unique($new_setting_value);
-		update_site_option('auto_update_plugins', $new_setting_value);
+		$this->update_option('auto_update_plugins', $new_setting_value);
 	}
 
 	/**
 	 * Enable automatic updates for UDM
 	 */
 	public function enable_automatic_updates() {
-		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
+		$auto_update_plugins = $this->get_option('auto_update_plugins');
+		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
 		$auto_update_plugins[] = $this->relative_plugin_file;
 		$auto_update_plugins = array_unique($auto_update_plugins);
-		update_site_option('auto_update_plugins', $auto_update_plugins);
+		$this->update_option('auto_update_plugins', $auto_update_plugins);
 	}
 
 	/**
 	 * Disable automatic updates for UDM
 	 */
 	public function disable_automatic_updates() {
-		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
+		$auto_update_plugins = $this->get_option('auto_update_plugins');
+		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
 		$auto_update_plugins = array_diff($auto_update_plugins, array($this->relative_plugin_file));
-		update_site_option('auto_update_plugins', $auto_update_plugins);
+		$this->update_option('auto_update_plugins', $auto_update_plugins);
 	}
 
 	/**
@@ -981,7 +988,8 @@ class Updraft_Manager_Updater_1_8 {
 	 * @return Boolean True if set, false otherwise
 	 */
 	public function is_automatic_updates() {
-		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
+		$auto_update_plugins = $this->get_option('auto_update_plugins');
+		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
 		return in_array($this->relative_plugin_file, $auto_update_plugins, true);
 	}
 }

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -760,7 +760,7 @@ class Updraft_Manager_Updater_1_8 {
 				$checkbox_id = 'udmupdater_autoupdate_'.$this->slug;
 				?>
 				<div class="udmupdater_autoupdate" style="clear:left;">
-					<input type="checkbox" id="<?php echo esc_attr($checkbox_id);?>" <?php if ($this->is_automatic_updates()) echo 'checked="checked"';?>>
+					<input type="checkbox" id="<?php echo esc_attr($checkbox_id);?>" <?php if ($this->is_automatic_updating_enabled()) echo 'checked="checked"';?>>
 					<label for="<?php echo esc_attr($checkbox_id);?>"><?php echo apply_filters('udmupdater_entercustomerlogin', __('Automatically update as soon as an update becomes available (N.B. other plugins can over-ride this setting).', 'udmupdater'), $this->slug);?></label>
 				</div>
 			<?php } ?>
@@ -993,7 +993,7 @@ class Updraft_Manager_Updater_1_8 {
 	 *
 	 * @return Boolean True if set, false otherwise
 	 */
-	protected function is_automatic_updates() {
+	protected function is_automatic_updating_enabled() {
 		$auto_update_plugins = $this->get_option('auto_update_plugins');
 		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
 		return in_array($this->relative_plugin_file, $auto_update_plugins, true);

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -87,7 +87,10 @@ class Updraft_Manager_Updater_1_8 {
 			Maintain compatibility on all versions between WordPress and UDM, specifically since WordPress 5.5 and UDM 1.8.8
 			Due to the new WP's auto-updates interface in WordPress version 5.5, we need to maintain the auto update compatibility on all versions of WordPress and UDM
 		*/
-		$this->remove_auto_update_option();
+		if (!$this->get_option('run_replace_auto_update_option_once')) {
+			$this->replace_auto_update_option();
+			$this->update_option('run_replace_auto_update_option_once', true);
+		}
 
 		if (version_compare($wp_version, '5.5', '<')) {
 			// Auto update plugin
@@ -948,7 +951,7 @@ class Updraft_Manager_Updater_1_8 {
 	 * Remove the use of auto_update index and its value from the *_updater_options option/meta (single/multisite) and change it to auto_update_plugins site option, which is also used by WordPress's core since version 5.5
 	 * This needs to be done in order to maintain auto-updates compatibility between WordPress and UDM and to synchronise the auto-updates setting for both
 	 */
-	public function remove_auto_update_option() {
+	public function replace_auto_update_option() {
 		$options = $this->get_option($this->option_name);
 		if (!is_array($options)) $options = array();
 		$old_setting_value = isset($options['auto_update']) ? $options['auto_update'] : '';

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -43,8 +43,6 @@ class Updraft_Manager_Updater_1_8 {
 	 */
 	public function __construct($mothership, $muid, $relative_plugin_file, $options = array()) {
 
-		global $wp_version;
-
 		include(ABSPATH.WPINC.'/version.php');
 
 		$this->auto_backoff = isset($options['auto_backoff']) ? $options['auto_backoff'] : true;
@@ -86,16 +84,15 @@ class Updraft_Manager_Updater_1_8 {
 		add_action('core_upgrade_preamble', array($this, 'core_upgrade_preamble'));
 		
 		/**
-		 * Maintain compatibility on all versions between WordPress and UDM, specifically since WordPress 5.5 and UDM 1.8.8
+		 * Maintain compatibility on all versions between WordPress and UDM, specifically since WordPress 5.5
 		 * Due to the new WP's auto-updates interface in WordPress version 5.5, we need to maintain the auto update compatibility on all versions of WordPress and UDM
 		 */
 		$udm_options = $this->get_option($this->option_name);
-		if (empty($udm_options['run_replace_auto_update_option_once'])) {
+		if (empty($udm_options['wp55_option_migrated'])) {
 			$this->replace_auto_update_option();
 		}
 
 		if (version_compare($wp_version, '5.5', '<')) {
-			// Auto update plugin
 			add_filter('auto_update_plugin', array($this, 'auto_update_plugin'), 20, 2);
 		}
 	}
@@ -959,9 +956,9 @@ class Updraft_Manager_Updater_1_8 {
 		if (!empty($old_setting_value)) $new_setting_value[] = $this->relative_plugin_file;
 		$new_setting_value = array_unique($new_setting_value);
 		unset($options['auto_update']);
-		$options['run_replace_auto_update_option_once'] = true;
+		$options['wp55_option_migrated'] = true;
 		$this->update_option($this->option_name, $options);
-		update_site_option('auto_update_plugins', $auto_update_plugins);
+		update_site_option('auto_update_plugins', $new_setting_value);
 	}
 
 	/**

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -169,9 +169,7 @@ class Updraft_Manager_Updater_1_8 {
 
 		if (!isset($item->slug) || $item->slug != $this->slug || !$this->allow_auto_updates) return $update;
 
-		$option_auto_update_settings = $this->get_option('auto_update_plugins');
-
-		if (!is_array($option_auto_update_settings)) $option_auto_update_settings = array();
+		$option_auto_update_settings = (array) get_site_option('auto_update_plugins', array());
 		
 		$update = in_array($item->plugin, $option_auto_update_settings, true);
 		
@@ -957,35 +955,32 @@ class Updraft_Manager_Updater_1_8 {
 		$options = $this->get_option($this->option_name);
 		if (!is_array($options)) $options = array();
 		$old_setting_value = isset($options['auto_update']) ? $options['auto_update'] : '';
-		$new_setting_value = $this->get_option('auto_update_plugins');
-		if (!is_array($new_setting_value)) $new_setting_value = array();
+		$new_setting_value = (array) get_site_option('auto_update_plugins', array());
 		if (!empty($old_setting_value)) $new_setting_value[] = $this->relative_plugin_file;
 		$new_setting_value = array_unique($new_setting_value);
 		unset($options['auto_update']);
 		$options['run_replace_auto_update_option_once'] = true;
 		$this->update_option($this->option_name, $options);
-		$this->update_option('auto_update_plugins', $new_setting_value);
+		update_site_option('auto_update_plugins', $auto_update_plugins);
 	}
 
 	/**
 	 * Enable automatic updates for UDM
 	 */
 	protected function enable_automatic_updates() {
-		$auto_update_plugins = $this->get_option('auto_update_plugins');
-		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
+		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
 		$auto_update_plugins[] = $this->relative_plugin_file;
 		$auto_update_plugins = array_unique($auto_update_plugins);
-		$this->update_option('auto_update_plugins', $auto_update_plugins);
+		update_site_option('auto_update_plugins', $auto_update_plugins);
 	}
 
 	/**
 	 * Disable automatic updates for UDM
 	 */
 	protected function disable_automatic_updates() {
-		$auto_update_plugins = $this->get_option('auto_update_plugins');
-		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
+		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
 		$auto_update_plugins = array_diff($auto_update_plugins, array($this->relative_plugin_file));
-		$this->update_option('auto_update_plugins', $auto_update_plugins);
+		update_site_option('auto_update_plugins', $auto_update_plugins);
 	}
 
 	/**
@@ -994,8 +989,7 @@ class Updraft_Manager_Updater_1_8 {
 	 * @return Boolean True if set, false otherwise
 	 */
 	protected function is_automatic_updating_enabled() {
-		$auto_update_plugins = $this->get_option('auto_update_plugins');
-		if (!is_array($auto_update_plugins)) $auto_update_plugins = array();
+		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
 		return in_array($this->relative_plugin_file, $auto_update_plugins, true);
 	}
 }

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -84,7 +84,7 @@ class Updraft_Manager_Updater_1_8 {
 		add_action('core_upgrade_preamble', array($this, 'core_upgrade_preamble'));
 		
 		/*
-			Maintain compatibility on all versions between WordPress and UpdraftPlus, specifically since WordPress 5.5 and UDM 1.8.8
+			Maintain compatibility on all versions between WordPress and UDM, specifically since WordPress 5.5 and UDM 1.8.8
 			Due to the new WP's auto-updates interface in WordPress version 5.5, we need to maintain the auto update compatibility on all versions of WordPress and UDM
 		*/
 		$this->remove_auto_update_option();


### PR DESCRIPTION
@DavidAnderson684 This PR is a follow-up to the discussion we had on Trello a while ago. It integrates the plugin manager and WordPress 5.5's auto-updates UI. As discussed, we agreed to still use the `auto_update_plugin` filter to force the plugin's automatic updates (this is actually the current behaviour of the plugin manager) when this library runs on a WP 5.5's predecessor, and we do that because we want to keep supporting the older WP versions users. Also, in the next release (once this PR is approved), the `auto_update` index from the *_updater_options option is no longer used and has been replaced with `auto_update_plugins` option, which is also being used by WP's core to store the plugins' auto-updates setting since version 5.5. I've personally tested this PR in a variety of scenarios (e.g. upgrading from an older version to a new version) with WP 5.5.1 and an older version of WordPress that this library supports and everything works as expected.