### PR TITLE
Duplicate site id – disconnect method

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -987,10 +987,15 @@ class Updraft_Manager_Updater_1_8 {
 				}
 
 			} elseif (is_wp_error($result)) {
-				echo __('Errors occurred:','udmupdater').'<br>';
-				show_message($result);
+				echo json_encode(array(
+					'code' => 'WP_ERROR',
+					'data' => __('Errors occurred:','udmupdater').' '.$result->get_error_message()
+				));
 			} else {
-				echo __('Errors occurred:','udmupdater').' '.htmlspecialchars(serialize($result));
+				echo json_encode(array(
+					'code' => 'UNKNOWN_ERR',
+					'data' => __('Errors occurred:','udmupdater').' '.htmlspecialchars(serialize($result))
+				));
 			}
 		}
 	}

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -266,53 +266,7 @@ class Updraft_Manager_Updater_1_8 {
 			die;
 
 		} elseif ('disconnect' == $_REQUEST['subaction'] && current_user_can('update_plugins')) {
-
-			$options = $this->get_option($this->option_name);
-
-			if (empty($options['email'])) {
-				echo json_encode(array(
-					'code' => 'INVALID',
-					'data' => 'Not connected (no email found)'
-				));
-			} else {
-				$result = wp_remote_post($this->url.'&udm_action=releaseaddon&slug='.urlencode($_POST['slug']).'&e='.urlencode($options['email']),
-					apply_filters('udmupdater_wp_api_options', array(
-						'timeout' => 10,
-						'body' => array(
-							'e' => $options['email'],
-							'sid' => $this->site_id(),
-							'slug' => $_POST['slug']
-						)
-					), 'releaseaddon')
-				);
-
-				if (is_array($result) && isset($result['body'])) {
-
-					$decoded = json_decode($result['body'], true);
-					if (empty($decoded)) {
-						echo json_encode(array(
-							'code' => 'INVALID',
-							'data' => $result['body']
-						));
-					} else {
-						echo $result['body'];
-						// Disconnect if their email address was not recognised; they probably changed it (and they're not going to be able to get any updates if it's not recognised anyway).
-						if (isset($decoded['code']) && ('OK' == $decoded['code'] || ('BADAUTH' == $decoded['code'] && isset($decoded['data']) && 'invaliduser' === $decoded['data']))) {
-							$option = $this->get_option($this->option_name);
-							if (!is_array($option)) $option = array();
-							unset($option['email']);
-							$this->update_option($this->option_name, $option);
-						}
-					}
-
-				} elseif (is_wp_error($result)) {
-					echo __('Errors occurred:','udmupdater').'<br>';
-					show_message($result);
-				} else {
-					echo __('Errors occurred:','udmupdater').' '.htmlspecialchars(serialize($result));
-				}
-			}
-
+			$this->disconnect();
 			die();
 		} elseif ('dismissexpiry' == $_REQUEST['subaction']) {
 
@@ -988,6 +942,57 @@ class Updraft_Manager_Updater_1_8 {
 	protected function is_automatic_updating_enabled() {
 		$auto_update_plugins = (array) get_site_option('auto_update_plugins', array());
 		return in_array($this->relative_plugin_file, $auto_update_plugins, true);
+	}
+
+	/**
+	 * Disconnect access to updates to the plugin
+	 */
+	public function disconnect() {
+		$options = $this->get_option($this->option_name);
+
+		if (empty($options['email'])) {
+			echo json_encode(array(
+				'code' => 'INVALID',
+				'data' => 'Not connected (no email found)'
+			));
+		} else {
+			$result = wp_remote_post($this->url.'&udm_action=releaseaddon&slug='.urlencode($_POST['slug']).'&e='.urlencode($options['email']),
+				apply_filters('udmupdater_wp_api_options', array(
+					'timeout' => 10,
+					'body' => array(
+						'e' => $options['email'],
+						'sid' => $this->site_id(),
+						'slug' => $_POST['slug']
+					)
+				), 'releaseaddon')
+			);
+
+			if (is_array($result) && isset($result['body'])) {
+
+				$decoded = json_decode($result['body'], true);
+				if (empty($decoded)) {
+					echo json_encode(array(
+						'code' => 'INVALID',
+						'data' => $result['body']
+					));
+				} else {
+					echo $result['body'];
+					// Disconnect if their email address was not recognised; they probably changed it (and they're not going to be able to get any updates if it's not recognised anyway).
+					if (isset($decoded['code']) && ('OK' == $decoded['code'] || ('BADAUTH' == $decoded['code'] && isset($decoded['data']) && 'invaliduser' === $decoded['data']))) {
+						$option = $this->get_option($this->option_name);
+						if (!is_array($option)) $option = array();
+						unset($option['email']);
+						$this->update_option($this->option_name, $option);
+					}
+				}
+
+			} elseif (is_wp_error($result)) {
+				echo __('Errors occurred:','udmupdater').'<br>';
+				show_message($result);
+			} else {
+				echo __('Errors occurred:','udmupdater').' '.htmlspecialchars(serialize($result));
+			}
+		}
 	}
 }
 endif;

--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -947,7 +947,7 @@ class Updraft_Manager_Updater_1_8 {
 	/**
 	 * Disconnect access to updates to the plugin
 	 */
-	public function disconnect() {
+	protected function disconnect() {
 		$options = $this->get_option($this->option_name);
 
 		if (empty($options['email'])) {


### PR DESCRIPTION
@DavidAnderson684 This PR moves the `disconnect` block of code into its own method as requested in this PR's discussion https://github.com/DavidAnderson684/simba-plugin-manager-updater/pull/11#discussion_r534523263, also I added few changes on how we handle the response of the `wp_remote_post` function when it returns a `WP_Error` object or other error, transforming the response into a formatted JSON string that has a specific error code (WP_ERROR or UNKNOWN_ERR). Those changes were made due to your question about the `network timeout` message in this discussion: https://github.com/DavidAnderson684/simba-plugin-manager-updater/pull/11#discussion_r534522806, actually, the `network timeout` message in that PR was used to handle the `WP_Error` response from the `wp_remote_post` function. If it returns a `WP_Error`, it likely means that there was a connectivity issue, which I previously presumed as `network timeout`, but I've now changed it (in the other PR) so that every time the `Disconnect` method fails, the frontend should able to display the corresponding message from the WP_Error object.