### PR TITLE
remove dynamic property creation

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -36,6 +36,10 @@ class Updraft_Manager_Updater_1_8 {
 	
 	private $plugin_data = null;
 
+    private $ourdir;
+
+    private $plugin_file;
+
 	/**
 	 * Constructor
 	 *


### PR DESCRIPTION
@DavidAnderson684 php 8.2 throws deprecation notice for dynamically created properties. This PR fixes it. 
However, it seems you also needs to update dependency https://github.com/YahnisElsts/plugin-update-checker/

I haven't done that because I'm not sure version 5.0 or needs to stay with version 4.13.*