### PR TITLE
Disconnect the site that has no license

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -433,7 +433,8 @@ class Updraft_Manager_Updater_1_9 {
 	 * @return YahnisElsts\PluginUpdateChecker\v5p5\Plugin\PluginInfo
 	 */
 	public function puc_request_info_result($info) {
-		if ($this->is_connected() && empty($info->toStdClass()->extraProperties['x-spm-connected'])) {
+		$extra_properties = $info->toStdClass()->extraProperties;
+		if ($this->is_connected() && !empty($extra_properties['x-spm-version']) && version_compare($extra_properties['x-spm-version'], '1.11.12', '>') && empty($extra_properties['x-spm-connected'])) {
 			$this->disconnect();
 			if ($this->debug) error_log("udm_updater: ".$this->slug." - the site was disconnected because the license is invalid.");
 		}


### PR DESCRIPTION
@DavidAnderson684 In the Simba Plugin Updates Manager plugin, there is a new attribute on the plugin update response named `x-spm-connected` that indicates whether the site is connected to the license. This PR checks the `x-spm-connected` attribute and automatically disconnects the site locally if it has no license connected.

**How to test this branch:**

1. Go to the Installed Plugins page.
2. Connect your site to your test plugin's license.

<img width="300" alt="1" src="https://github.com/user-attachments/assets/691bfe63-d21d-4dc7-9383-a0ef798e89bf" />

3. Go to the user's plugin entitlements and click the reset link on your site.

<img width="250" alt="2" src="https://github.com/user-attachments/assets/6d58625e-5db7-4d2a-a3c5-6504ee797e2e" />

4. Go to the Installed Plugins page.
5. Click the `Check for updates` link on your test plugin.

<img width="300" alt="3" src="https://github.com/user-attachments/assets/a0db11d8-1900-4b25-8ce4-e6730983df28" />

6. You should see that you're disconnected.

<img width="300" alt="4" src="https://github.com/user-attachments/assets/61e67453-2e17-4cad-ba47-2abe7e1a3844" />
