### PR TITLE
yahnis-elsts/plugin-update-checker version 5.6 latest update

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -9,7 +9,7 @@ Licence: MIT / GPLv2+
 if (!class_exists('Updraft_Manager_Updater_1_9')):
 class Updraft_Manager_Updater_1_9 {
 
-	public $version = '1.9.5';
+	public $version = '1.9.6';
 
 	public $relative_plugin_file;
 	public $slug;

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
 	"name": "davidanderson684/simba-plugin-manager-updater",
 	"description": "This class is an updates checker and UI for WordPress plugins that are hosted using the Simba Plugin Manager plugin",
 	"require": {
-		"yahnis-elsts/plugin-update-checker": "5.5.*"
+		"yahnis-elsts/plugin-update-checker": "5.6.*"
 	}
 }


### PR DESCRIPTION
Deprecated: YahnisElsts\PluginUpdateChecker\v5p5\UpdateChecker::fixSupportedWordpressVersion(): Implicitly marking parameter $update as nullable is deprecated solved.