### PR TITLE
Make is_connected() public to avoid reflection-based access

### DIFF
--- a/class-udm-updater.php
+++ b/class-udm-updater.php
@@ -460,7 +460,7 @@ class Updraft_Manager_Updater_1_9 {
 	 *
 	 * @return Boolean
 	 */
-	protected function is_connected() {
+	public function is_connected() {
 		$option = $this->get_option($this->option_name);
 		return empty($option['email']) ? false : true;
 	}


### PR DESCRIPTION
This PR exposes the license connection state via a public method,
removing the need for downstream plugins to rely on PHP Reflection
to access protected internals.

No behavior change — only visibility.
Fully backwards compatible.


Code like 
```
try {
/*
* The is_connected() method is protected in class Updraft_Manager_Updater_1_9.
* So we cannot call it directly from outside the class without using ReflectionClass.
*/
	$reflection = new ReflectionClass($updraft_updater_instance);
	if (!$reflection->hasMethod('is_connected')) {
		return false;
	}
	$method = $reflection->getMethod('is_connected');
	$method->setAccessible(true);

	return (bool) $method->invoke($updraft_updater_instance);
} catch (\Throwable $e) {
	// Any exception results in returning false
	return false;
}
```

can be changed to 

`return (bool) $updraft_updater_instance->is_connected();`

